### PR TITLE
Implement terminal scaling.

### DIFF
--- a/src/menu.rs
+++ b/src/menu.rs
@@ -50,7 +50,7 @@ fn library_menu() {
         .collect();
 
     let ans = Select::new("Games", game_names)
-        .with_page_size(32)
+        .with_page_size((utils::get_terminal_height() - 2) as usize)
         .prompt()
         .expect("Failed to select a game.");
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -4,7 +4,8 @@ use crossterm::{
     execute,
     terminal::{
         Clear,
-        ClearType
+        ClearType,
+        size
     },
     cursor::MoveTo
 };
@@ -15,4 +16,9 @@ pub fn clear_screen() {
         Clear(ClearType::All),
         MoveTo(0, 0)
     ).unwrap();
+}
+
+pub fn get_terminal_height() -> u16 {
+    let (_, height) = size().unwrap();
+    height
 }


### PR DESCRIPTION
This fixes the default sizing on the Windows command prompt too.